### PR TITLE
fix(installer): guard optional function calls that fatal on PHP 8.2

### DIFF
--- a/htdocs/install/page_modcheck.php
+++ b/htdocs/install/page_modcheck.php
@@ -59,7 +59,7 @@ ob_start();
 
         <tr>
             <th><?php printf(PHP_EXTENSION, 'MySQLi'); ?></th>
-            <td><?php echo xoDiag(function_exists('mysqli_connect') ? 1 : -1, @mysqli_get_client_info()); ?></td>
+            <td><?php echo xoDiag(function_exists('mysqli_connect') ? 1 : -1, function_exists('mysqli_get_client_info') ? @mysqli_get_client_info() : ''); ?></td>
         </tr>
 
         <tr>

--- a/htdocs/install/page_modcheck.php
+++ b/htdocs/install/page_modcheck.php
@@ -59,7 +59,7 @@ ob_start();
 
         <tr>
             <th><?php printf(PHP_EXTENSION, 'MySQLi'); ?></th>
-            <td><?php echo xoDiag(function_exists('mysqli_connect') ? 1 : -1, function_exists('mysqli_get_client_info') ? @mysqli_get_client_info() : ''); ?></td>
+            <td><?php echo xoDiag(function_exists('mysqli_connect') ? 1 : -1, function_exists('mysqli_get_client_info') ? mysqli_get_client_info() : ''); ?></td>
         </tr>
 
         <tr>

--- a/htdocs/xoops_lib/modules/protector/class/protector.php
+++ b/htdocs/xoops_lib/modules/protector/class/protector.php
@@ -62,7 +62,8 @@ class Protector
         $this->mydirname = 'protector';
 
         // Preferences from configs/cache
-        $this->_conf_serialized = @file_get_contents($this->get_filepath4confighcache());
+        $confcache = $this->get_filepath4confighcache();
+        $this->_conf_serialized = is_file($confcache) ? (string)file_get_contents($confcache) : '';
         $this->_conf            = @unserialize($this->_conf_serialized, ['allowed_classes' => false]);
         if (empty($this->_conf)) {
             $this->_conf = [];


### PR DESCRIPTION
## Summary

Two unrelated installer-time crashes encountered during XOOPS 2.7.0 install testing on **PHP 8.2.31 / MySQL 5.7.44 / Apache 2.4.66 (Windows)**. Both share one root cause: PHP's `@` operator does not suppress *undefined function* fatal errors, and XOOPS's custom error handler (`XoopsLogger`) ignores `@` for warnings — so each spot either fataled or spammed `log.txt` whenever the called function / backing file was absent.

- **`install/page_modcheck.php`** — `@mysqli_get_client_info()` was evaluated unconditionally as an argument to `xoDiag()`. When the mysqli extension is not loaded, this is a fatal "Call to undefined function", crashing the very requirements page meant to *report* the missing extension. Now guarded with `function_exists()`, passing an empty info string when absent; `xoDiag()` still flags MySQLi as missing via the existing `function_exists('mysqli_connect')` check.

- **`xoops_lib/modules/protector/class/protector.php`** — the constructor read its configcache via `@file_get_contents()` before that cache file is ever written. On a fresh install the cache does not exist until `postcheck_functions.php` calls `updateConfFromDb()`; every page in between logged a warning because the XOOPS error handler does not honour `@`. Now guarded with `is_file()`, treating a missing cache as an empty serialized payload (the existing unserialize/`empty()` checks already handle that shape).

## Test plan

- [ ] On PHP 8.2 with the mysqli extension **disabled**, load the installer requirements page — renders, MySQLi shown as missing (no fatal).
- [ ] With mysqli **enabled**, installer requirements page shows MySQLi present with client info as before.
- [ ] Fresh 2.7.0 install: confirm `log.txt` no longer accumulates `file_get_contents(... protector/configcache...)` warnings on every page prior to first Protector preferences save.
- [ ] After Admin → Modules → Protector → Preferences → Save, confirm the configcache file is written and Protector behaves normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system diagnostics for database connectivity with more robust function availability detection.
  * Enhanced stability by validating configuration cache files before loading, reducing potential initialization errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mambax7/XoopsCore27/pull/8)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->